### PR TITLE
Fixing the "Whirlwind introduction to Python" dead link on the course website

### DIFF
--- a/_sources/Week_01.md
+++ b/_sources/Week_01.md
@@ -18,7 +18,7 @@ You will start with an overview of the course and then an introduction to statis
 * {doc}`homework/Homework_01`
 
 ## *Supplemental Readings*
-  * A Whirlwind Tour of Python*, Jake VanderPlas: [free PDF](http://www.oreilly.com/programming/free/files/a-whirlwind-tour-of-python.pdf), notebooks [online](http://nbviewer.jupyter.org/github/jakevdp/WhirlwindTourOfPython/blob/master/Index.ipynb).
+  * A Whirlwind Tour of Python*, Jake VanderPlas: [book website](https://jakevdp.github.io/WhirlwindTourOfPython/), notebooks [online](http://nbviewer.jupyter.org/github/jakevdp/WhirlwindTourOfPython/blob/master/Index.ipynb).
   * [IPython: Beyond Normal Python](https://jakevdp.github.io/PythonDataScienceHandbook/01.00-ipython-beyond-normal-python.html)
   * [Python Data Science Handbook](https://jakevdp.github.io/PythonDataScienceHandbook/index.html)
   * [Introduction to NumPy](https://jakevdp.github.io/PythonDataScienceHandbook/02.00-introduction-to-numpy.html)


### PR DESCRIPTION
On the "Course Introduction" page (Week_01.md) there was a dead link for the "Whirlwind Introduction to Python". I ended up finding a github.io web page for the same book. Given that it's on Jake VanderPlas' github.io website it should be consistently available.