### PR TITLE
Changing the HW #3 asserts to account for eigenvectors of different directions

### DIFF
--- a/_sources/homework/Homework_03.ipynb
+++ b/_sources/homework/Homework_03.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -64,24 +64,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "File ‘./tmp_data/spectra_data.hf5’ already there; not retrieving.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "wget_data('https://raw.githubusercontent.com/illinois-ipaml/MachineLearningForPhysics/main/data/spectra_data.hf5')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -138,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {
     "deletable": false,
     "nbgrader": {
@@ -180,10 +172,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
+    "#A function to check work\n",
     "def checkEigens(evals: np.ndarray, evecs: np.ndarray, covariance: np.ndarray, knownEvals: np.ndarray, knownEvecs: np.ndarray):\n",
     "    assert np.allclose(covariance, evecs.T.dot(np.diag(evals).dot(evecs)))\n",
     "    assert np.allclose(\n",
@@ -200,7 +193,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {
     "deletable": false,
     "editable": false,
@@ -214,20 +207,7 @@
      "solution": false
     }
    },
-   "outputs": [
-    {
-     "ename": "NotImplementedError",
-     "evalue": "",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNotImplementedError\u001b[0m                       Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[20], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;66;03m# A correct solution should pass the tests below.\u001b[39;00m\n\u001b[1;32m      2\u001b[0m C \u001b[38;5;241m=\u001b[39m np\u001b[38;5;241m.\u001b[39mdiag(np\u001b[38;5;241m.\u001b[39marange(\u001b[38;5;241m1.\u001b[39m, \u001b[38;5;241m5.\u001b[39m))\n\u001b[0;32m----> 3\u001b[0m evals, evecs \u001b[38;5;241m=\u001b[39m \u001b[43meigensolve\u001b[49m\u001b[43m(\u001b[49m\u001b[43mC\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m      4\u001b[0m \u001b[38;5;66;03m# assert np.allclose(\u001b[39;00m\n\u001b[1;32m      5\u001b[0m \u001b[38;5;66;03m#     evals,\u001b[39;00m\n\u001b[1;32m      6\u001b[0m \u001b[38;5;66;03m#     [ 4.,  3.,  2.,  1.])\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     11\u001b[0m \u001b[38;5;66;03m#      [ 0.,  1.,  0.,  0.],\u001b[39;00m\n\u001b[1;32m     12\u001b[0m \u001b[38;5;66;03m#      [ 1.,  0.,  0.,  0.]])\u001b[39;00m\n\u001b[1;32m     14\u001b[0m checkEigens(evals, evecs, C, \n\u001b[1;32m     15\u001b[0m     knownEvals\u001b[38;5;241m=\u001b[39m[\u001b[38;5;241m4\u001b[39m, \u001b[38;5;241m3\u001b[39m, \u001b[38;5;241m2\u001b[39m, \u001b[38;5;241m1\u001b[39m],\n\u001b[1;32m     16\u001b[0m     knownEvecs\u001b[38;5;241m=\u001b[39m[[ \u001b[38;5;241m0.\u001b[39m,  \u001b[38;5;241m0.\u001b[39m,  \u001b[38;5;241m0.\u001b[39m,  \u001b[38;5;241m1.\u001b[39m],\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     19\u001b[0m      [ \u001b[38;5;241m1.\u001b[39m,  \u001b[38;5;241m0.\u001b[39m,  \u001b[38;5;241m0.\u001b[39m,  \u001b[38;5;241m0.\u001b[39m]]\n\u001b[1;32m     20\u001b[0m )\n",
-      "Cell \u001b[0;32mIn[18], line 24\u001b[0m, in \u001b[0;36meigensolve\u001b[0;34m(M)\u001b[0m\n\u001b[1;32m     22\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m np\u001b[38;5;241m.\u001b[39mall(M\u001b[38;5;241m.\u001b[39mT \u001b[38;5;241m==\u001b[39m M)\n\u001b[1;32m     23\u001b[0m \u001b[38;5;66;03m# YOUR CODE HERE\u001b[39;00m\n\u001b[0;32m---> 24\u001b[0m \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mNotImplementedError\u001b[39;00m()\n",
-      "\u001b[0;31mNotImplementedError\u001b[0m: "
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# A correct solution should pass the tests below.\n",
     "C = np.diag(np.arange(1., 5.))\n",
@@ -321,20 +301,7 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "ename": "AssertionError",
-     "evalue": "",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[12], line 33\u001b[0m\n\u001b[1;32m     31\u001b[0m evals, evecs \u001b[38;5;241m=\u001b[39m svdsolve(X)\n\u001b[1;32m     32\u001b[0m C \u001b[38;5;241m=\u001b[39m np\u001b[38;5;241m.\u001b[39mdot(X\u001b[38;5;241m.\u001b[39mT, X) \u001b[38;5;241m/\u001b[39m (N \u001b[38;5;241m-\u001b[39m \u001b[38;5;241m1\u001b[39m)\n\u001b[0;32m---> 33\u001b[0m \u001b[43mcheckEigens\u001b[49m\u001b[43m(\u001b[49m\u001b[43mevals\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mevecs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mC\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     34\u001b[0m \u001b[43m    \u001b[49m\u001b[43mknownEvals\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m \u001b[49m\u001b[43m[\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m0.23688\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m  \u001b[49m\u001b[38;5;241;43m0.03412\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m  \u001b[49m\u001b[38;5;241;43m0.\u001b[39;49m\u001b[43m     \u001b[49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     35\u001b[0m \u001b[43m    \u001b[49m\u001b[43mknownEvecs\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m \u001b[49m\u001b[43m[\u001b[49m\u001b[43m[\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m0.368\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m0.874\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m  \u001b[49m\u001b[38;5;241;43m0.316\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m-\u001b[39;49m\u001b[38;5;241;43m0.041\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     36\u001b[0m \u001b[43m     \u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;241;43m-\u001b[39;49m\u001b[38;5;241;43m0.752\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m0.178\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m  \u001b[49m\u001b[38;5;241;43m0.313\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m-\u001b[39;49m\u001b[38;5;241;43m0.553\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     37\u001b[0m \u001b[43m     \u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;241;43m-\u001b[39;49m\u001b[38;5;241;43m0.516\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m0.422\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m-\u001b[39;49m\u001b[38;5;241;43m0.496\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m  \u001b[49m\u001b[38;5;241;43m0.556\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m]\u001b[49m\n\u001b[1;32m     38\u001b[0m \u001b[43m)\u001b[49m\n",
-      "Cell \u001b[0;32mIn[12], line 6\u001b[0m, in \u001b[0;36mcheckEigens\u001b[0;34m(evals, evecs, covariance, knownEvals, knownEvecs)\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m np\u001b[38;5;241m.\u001b[39mallclose(covariance, evecs\u001b[38;5;241m.\u001b[39mT\u001b[38;5;241m.\u001b[39mdot(np\u001b[38;5;241m.\u001b[39mdiag(evals)\u001b[38;5;241m.\u001b[39mdot(evecs)))\n\u001b[1;32m      3\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m np\u001b[38;5;241m.\u001b[39mallclose(\n\u001b[1;32m      4\u001b[0m     np\u001b[38;5;241m.\u001b[39mround(evals, \u001b[38;5;241m5\u001b[39m),\n\u001b[1;32m      5\u001b[0m     knownEvals)\n\u001b[0;32m----> 6\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m np\u001b[38;5;241m.\u001b[39mallclose(\n\u001b[1;32m      7\u001b[0m     np\u001b[38;5;241m.\u001b[39mround(np\u001b[38;5;241m.\u001b[39mabs(evecs), \u001b[38;5;241m3\u001b[39m),\n\u001b[1;32m      8\u001b[0m     np\u001b[38;5;241m.\u001b[39mabs(knownEvecs)\n\u001b[1;32m      9\u001b[0m )\n\u001b[1;32m     10\u001b[0m \u001b[38;5;66;03m#Accounting for direction\u001b[39;00m\n\u001b[1;32m     11\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m calcRow, knownRow \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mzip\u001b[39m(np\u001b[38;5;241m.\u001b[39mround(evecs, \u001b[38;5;241m3\u001b[39m), knownEvecs):\n",
-      "\u001b[0;31mAssertionError\u001b[0m: "
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# A correct solution should pass the tests below.\n",
     "gen = np.random.RandomState(seed=123)\n",

--- a/_sources/homework/Homework_03.ipynb
+++ b/_sources/homework/Homework_03.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -64,16 +64,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "File ‘./tmp_data/spectra_data.hf5’ already there; not retrieving.\n"
+     ]
+    }
+   ],
    "source": [
     "wget_data('https://raw.githubusercontent.com/illinois-ipaml/MachineLearningForPhysics/main/data/spectra_data.hf5')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -130,7 +138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 18,
    "metadata": {
     "deletable": false,
     "nbgrader": {
@@ -172,7 +180,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def checkEigens(evals: np.ndarray, evecs: np.ndarray, covariance: np.ndarray, knownEvals: np.ndarray, knownEvecs: np.ndarray):\n",
+    "    assert np.allclose(covariance, evecs.T.dot(np.diag(evals).dot(evecs)))\n",
+    "    assert np.allclose(\n",
+    "        np.round(evals, 5),\n",
+    "        knownEvals)\n",
+    "    assert np.allclose(\n",
+    "        np.round(np.abs(evecs), 3),\n",
+    "        np.abs(knownEvecs)\n",
+    "    )\n",
+    "    #Accounting for direction\n",
+    "    for calcRow, knownRow in zip(np.round(evecs, 3), knownEvecs):\n",
+    "        assert np.allclose(calcRow, knownRow) or np.allclose(-1 * calcRow, knownRow)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
    "metadata": {
     "deletable": false,
     "editable": false,
@@ -186,20 +214,32 @@
      "solution": false
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NotImplementedError",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNotImplementedError\u001b[0m                       Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[20], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;66;03m# A correct solution should pass the tests below.\u001b[39;00m\n\u001b[1;32m      2\u001b[0m C \u001b[38;5;241m=\u001b[39m np\u001b[38;5;241m.\u001b[39mdiag(np\u001b[38;5;241m.\u001b[39marange(\u001b[38;5;241m1.\u001b[39m, \u001b[38;5;241m5.\u001b[39m))\n\u001b[0;32m----> 3\u001b[0m evals, evecs \u001b[38;5;241m=\u001b[39m \u001b[43meigensolve\u001b[49m\u001b[43m(\u001b[49m\u001b[43mC\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m      4\u001b[0m \u001b[38;5;66;03m# assert np.allclose(\u001b[39;00m\n\u001b[1;32m      5\u001b[0m \u001b[38;5;66;03m#     evals,\u001b[39;00m\n\u001b[1;32m      6\u001b[0m \u001b[38;5;66;03m#     [ 4.,  3.,  2.,  1.])\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     11\u001b[0m \u001b[38;5;66;03m#      [ 0.,  1.,  0.,  0.],\u001b[39;00m\n\u001b[1;32m     12\u001b[0m \u001b[38;5;66;03m#      [ 1.,  0.,  0.,  0.]])\u001b[39;00m\n\u001b[1;32m     14\u001b[0m checkEigens(evals, evecs, C, \n\u001b[1;32m     15\u001b[0m     knownEvals\u001b[38;5;241m=\u001b[39m[\u001b[38;5;241m4\u001b[39m, \u001b[38;5;241m3\u001b[39m, \u001b[38;5;241m2\u001b[39m, \u001b[38;5;241m1\u001b[39m],\n\u001b[1;32m     16\u001b[0m     knownEvecs\u001b[38;5;241m=\u001b[39m[[ \u001b[38;5;241m0.\u001b[39m,  \u001b[38;5;241m0.\u001b[39m,  \u001b[38;5;241m0.\u001b[39m,  \u001b[38;5;241m1.\u001b[39m],\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     19\u001b[0m      [ \u001b[38;5;241m1.\u001b[39m,  \u001b[38;5;241m0.\u001b[39m,  \u001b[38;5;241m0.\u001b[39m,  \u001b[38;5;241m0.\u001b[39m]]\n\u001b[1;32m     20\u001b[0m )\n",
+      "Cell \u001b[0;32mIn[18], line 24\u001b[0m, in \u001b[0;36meigensolve\u001b[0;34m(M)\u001b[0m\n\u001b[1;32m     22\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m np\u001b[38;5;241m.\u001b[39mall(M\u001b[38;5;241m.\u001b[39mT \u001b[38;5;241m==\u001b[39m M)\n\u001b[1;32m     23\u001b[0m \u001b[38;5;66;03m# YOUR CODE HERE\u001b[39;00m\n\u001b[0;32m---> 24\u001b[0m \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mNotImplementedError\u001b[39;00m()\n",
+      "\u001b[0;31mNotImplementedError\u001b[0m: "
+     ]
+    }
+   ],
    "source": [
     "# A correct solution should pass the tests below.\n",
     "C = np.diag(np.arange(1., 5.))\n",
     "evals, evecs = eigensolve(C)\n",
-    "assert np.allclose(\n",
-    "    evals,\n",
-    "    [ 4.,  3.,  2.,  1.])\n",
-    "assert np.allclose(\n",
-    "    evecs,\n",
-    "    [[ 0.,  0.,  0.,  1.],\n",
+    "\n",
+    "checkEigens(evals, evecs, C, \n",
+    "    knownEvals=[4, 3, 2, 1],\n",
+    "    knownEvecs=[[ 0.,  0.,  0.,  1.],\n",
     "     [ 0.,  0.,  1.,  0.],\n",
     "     [ 0.,  1.,  0.,  0.],\n",
-    "     [ 1.,  0.,  0.,  0.]])\n",
+    "     [ 1.,  0.,  0.,  0.]]\n",
+    ")\n",
     "\n",
     "gen = np.random.RandomState(seed=123)\n",
     "N, D = 4, 3\n",
@@ -207,15 +247,12 @@
     "X -= np.mean(X, axis=0)\n",
     "C = np.dot(X.T, X) / (N - 1)\n",
     "evals, evecs = eigensolve(C)\n",
-    "assert np.allclose(C, evecs.T.dot(np.diag(evals).dot(evecs)))\n",
-    "assert np.allclose(\n",
-    "    np.round(evals, 5),\n",
-    "    [ 0.08825,  0.0481 ,  0.01983])\n",
-    "assert np.allclose(\n",
-    "    np.round(evecs, 3),\n",
-    "    [[-0.787, -0.477,  0.391],\n",
+    "checkEigens(evals, evecs, C,\n",
+    "    knownEvals=[ 0.08825,  0.0481 ,  0.01983],\n",
+    "    knownEvecs=[[-0.787, -0.477,  0.391],\n",
     "     [-0.117,  0.737,  0.665],\n",
-    "     [-0.606,  0.478, -0.636]])"
+    "     [-0.606,  0.478, -0.636]]\n",
+    ")"
    ]
   },
   {
@@ -284,7 +321,20 @@
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "AssertionError",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[12], line 33\u001b[0m\n\u001b[1;32m     31\u001b[0m evals, evecs \u001b[38;5;241m=\u001b[39m svdsolve(X)\n\u001b[1;32m     32\u001b[0m C \u001b[38;5;241m=\u001b[39m np\u001b[38;5;241m.\u001b[39mdot(X\u001b[38;5;241m.\u001b[39mT, X) \u001b[38;5;241m/\u001b[39m (N \u001b[38;5;241m-\u001b[39m \u001b[38;5;241m1\u001b[39m)\n\u001b[0;32m---> 33\u001b[0m \u001b[43mcheckEigens\u001b[49m\u001b[43m(\u001b[49m\u001b[43mevals\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mevecs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mC\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     34\u001b[0m \u001b[43m    \u001b[49m\u001b[43mknownEvals\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m \u001b[49m\u001b[43m[\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m0.23688\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m  \u001b[49m\u001b[38;5;241;43m0.03412\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m  \u001b[49m\u001b[38;5;241;43m0.\u001b[39;49m\u001b[43m     \u001b[49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     35\u001b[0m \u001b[43m    \u001b[49m\u001b[43mknownEvecs\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m \u001b[49m\u001b[43m[\u001b[49m\u001b[43m[\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m0.368\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m0.874\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m  \u001b[49m\u001b[38;5;241;43m0.316\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m-\u001b[39;49m\u001b[38;5;241;43m0.041\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     36\u001b[0m \u001b[43m     \u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;241;43m-\u001b[39;49m\u001b[38;5;241;43m0.752\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m0.178\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m  \u001b[49m\u001b[38;5;241;43m0.313\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m-\u001b[39;49m\u001b[38;5;241;43m0.553\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     37\u001b[0m \u001b[43m     \u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;241;43m-\u001b[39;49m\u001b[38;5;241;43m0.516\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m0.422\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m-\u001b[39;49m\u001b[38;5;241;43m0.496\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m  \u001b[49m\u001b[38;5;241;43m0.556\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m]\u001b[49m\n\u001b[1;32m     38\u001b[0m \u001b[43m)\u001b[49m\n",
+      "Cell \u001b[0;32mIn[12], line 6\u001b[0m, in \u001b[0;36mcheckEigens\u001b[0;34m(evals, evecs, covariance, knownEvals, knownEvecs)\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m np\u001b[38;5;241m.\u001b[39mallclose(covariance, evecs\u001b[38;5;241m.\u001b[39mT\u001b[38;5;241m.\u001b[39mdot(np\u001b[38;5;241m.\u001b[39mdiag(evals)\u001b[38;5;241m.\u001b[39mdot(evecs)))\n\u001b[1;32m      3\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m np\u001b[38;5;241m.\u001b[39mallclose(\n\u001b[1;32m      4\u001b[0m     np\u001b[38;5;241m.\u001b[39mround(evals, \u001b[38;5;241m5\u001b[39m),\n\u001b[1;32m      5\u001b[0m     knownEvals)\n\u001b[0;32m----> 6\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m np\u001b[38;5;241m.\u001b[39mallclose(\n\u001b[1;32m      7\u001b[0m     np\u001b[38;5;241m.\u001b[39mround(np\u001b[38;5;241m.\u001b[39mabs(evecs), \u001b[38;5;241m3\u001b[39m),\n\u001b[1;32m      8\u001b[0m     np\u001b[38;5;241m.\u001b[39mabs(knownEvecs)\n\u001b[1;32m      9\u001b[0m )\n\u001b[1;32m     10\u001b[0m \u001b[38;5;66;03m#Accounting for direction\u001b[39;00m\n\u001b[1;32m     11\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m calcRow, knownRow \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mzip\u001b[39m(np\u001b[38;5;241m.\u001b[39mround(evecs, \u001b[38;5;241m3\u001b[39m), knownEvecs):\n",
+      "\u001b[0;31mAssertionError\u001b[0m: "
+     ]
+    }
+   ],
    "source": [
     "# A correct solution should pass the tests below.\n",
     "gen = np.random.RandomState(seed=123)\n",
@@ -293,30 +343,24 @@
     "X -= np.mean(X, axis=0)\n",
     "evals, evecs = svdsolve(X)\n",
     "C = np.dot(X.T, X) / (N - 1)\n",
-    "assert np.allclose(C, evecs.T.dot(np.diag(evals).dot(evecs)))\n",
-    "assert np.allclose(\n",
-    "    np.round(evals, 5),\n",
-    "    [ 0.08825,  0.0481 ,  0.01983])\n",
-    "assert np.allclose(\n",
-    "    np.round(evecs, 3),\n",
-    "    [[-0.787, -0.477,  0.391],\n",
+    "checkEigens(evals, evecs, C,\n",
+    "    knownEvals= [ 0.08825,  0.0481 ,  0.01983],\n",
+    "    knownEvecs= [[-0.787, -0.477,  0.391],\n",
     "     [ 0.117, -0.737, -0.665],\n",
-    "     [-0.606,  0.478, -0.636]])\n",
+    "     [-0.606,  0.478, -0.636]]\n",
+    ")\n",
     "\n",
     "N, D = 3, 4\n",
     "X = gen.uniform(size=(N, D))\n",
     "X -= np.mean(X, axis=0)\n",
     "evals, evecs = svdsolve(X)\n",
     "C = np.dot(X.T, X) / (N - 1)\n",
-    "assert np.allclose(C, evecs.T.dot(np.diag(evals).dot(evecs)))\n",
-    "assert np.allclose(\n",
-    "    np.round(evals, 5),\n",
-    "    [ 0.23688,  0.03412,  0.     ])\n",
-    "assert np.allclose(\n",
-    "    np.round(evecs, 3),\n",
-    "    [[ 0.368, 0.874,  0.316, -0.041],\n",
+    "checkEigens(evals, evecs, C,\n",
+    "    knownEvals= [ 0.23688,  0.03412,  0.     ],\n",
+    "    knownEvecs= [[ 0.368, 0.874,  0.316, -0.041],\n",
     "     [-0.752, 0.178,  0.313, -0.553],\n",
-    "     [-0.516, 0.422, -0.496,  0.556]])"
+    "     [-0.516, 0.422, -0.496,  0.556]]\n",
+    ")"
    ]
   },
   {
@@ -426,7 +470,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "metadata": {
     "deletable": false,
     "nbgrader": {
@@ -519,7 +563,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.11.4 ('venv': venv)",
    "language": "python",
    "name": "python3"
   },
@@ -533,7 +577,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.2"
+   "version": "3.11.4"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "97dba3eac0b24fb4cc89926c6b98e4bb005345d7d81214baa40ef267167fd20b"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The assertions for HW # 3 occasionally fail despite the answer being conceptually correct. The usual cause for this is a different direction for the eigenvectors.

This adds to the assertions to allow for the eigenvectors to be different than expected.

I did this via a helper assertion function since the assertions were similar. This can be changed back if needed though!